### PR TITLE
Add automatic-transmission K8s container jobs with staggered scheduling

### DIFF
--- a/config/dagster.yaml
+++ b/config/dagster.yaml
@@ -3,8 +3,13 @@ scheduler:
   class: DagsterDaemonScheduler
 
 run_launcher:
-  module: dagster.core.launcher
-  class: DefaultRunLauncher
+  module: dagster_k8s
+  class: K8sRunLauncher
+  config:
+    service_account_name: dagster
+    job_namespace: orchestration
+    load_incluster_config: true
+    job_image: dagster/dagster-k8s:1.5.5
 
 storage:
   postgres:

--- a/dagstributor/automatic_transmission/__init__.py
+++ b/dagstributor/automatic_transmission/__init__.py
@@ -1,0 +1,1 @@
+"""Automatic transmission container jobs for Dagster."""

--- a/dagstributor/automatic_transmission/jobs.py
+++ b/dagstributor/automatic_transmission/jobs.py
@@ -1,0 +1,76 @@
+"""Job definitions for automatic transmission pipeline."""
+
+from dagster import job
+
+from .ops import (
+    rss_ingest_op,
+    collect_op,
+    parse_op,
+    file_filtration_op,
+    metadata_collection_op,
+    media_filtration_op,
+    initiation_op,
+    download_check_op,
+    transfer_op,
+    cleanup_op,
+)
+
+
+@job
+def rss_ingest_job():
+    """RSS Ingest job - runs at :00 minutes."""
+    rss_ingest_op()
+
+
+@job
+def collect_job():
+    """Collect job - runs at :06 minutes."""
+    collect_op()
+
+
+@job
+def parse_job():
+    """Parse job - runs at :12 minutes."""
+    parse_op()
+
+
+@job
+def file_filtration_job():
+    """File Filtration job - runs at :18 minutes."""
+    file_filtration_op()
+
+
+@job
+def metadata_collection_job():
+    """Metadata Collection job - runs at :24 minutes."""
+    metadata_collection_op()
+
+
+@job
+def media_filtration_job():
+    """Media Filtration job - runs at :30 minutes."""
+    media_filtration_op()
+
+
+@job
+def initiation_job():
+    """Initiation job - runs at :36 minutes."""
+    initiation_op()
+
+
+@job
+def download_check_job():
+    """Download Check job - runs at :42 minutes."""
+    download_check_op()
+
+
+@job
+def transfer_job():
+    """Transfer job - runs at :48 minutes."""
+    transfer_op()
+
+
+@job
+def cleanup_job():
+    """Cleanup job - runs at :54 minutes."""
+    cleanup_op()

--- a/dagstributor/automatic_transmission/ops.py
+++ b/dagstributor/automatic_transmission/ops.py
@@ -1,0 +1,115 @@
+"""Kubernetes container execution ops for automatic transmission pipeline."""
+
+import os
+from dagster import op, OpExecutionContext
+from dagster_k8s import k8s_job_op
+
+
+@k8s_job_op(
+    container_config={
+        "image": f"ghcr.io/x81k25/automatic-transmission/at-rss-ingest:{os.getenv('ENVIRONMENT', 'latest')}",
+        "env_config_maps": ["dagster-pipeline-env"],
+    }
+)
+def rss_ingest_op(context: OpExecutionContext):
+    """RSS Ingest container operation."""
+    context.log.info("Running RSS Ingest container")
+
+
+@k8s_job_op(
+    container_config={
+        "image": f"ghcr.io/x81k25/automatic-transmission/at-collect:{os.getenv('ENVIRONMENT', 'latest')}",
+        "env_config_maps": ["dagster-pipeline-env"],
+    }
+)
+def collect_op(context: OpExecutionContext):
+    """Collect container operation."""
+    context.log.info("Running Collect container")
+
+
+@k8s_job_op(
+    container_config={
+        "image": f"ghcr.io/x81k25/automatic-transmission/at-parse:{os.getenv('ENVIRONMENT', 'latest')}",
+        "env_config_maps": ["dagster-pipeline-env"],
+    }
+)
+def parse_op(context: OpExecutionContext):
+    """Parse container operation."""
+    context.log.info("Running Parse container")
+
+
+@k8s_job_op(
+    container_config={
+        "image": f"ghcr.io/x81k25/automatic-transmission/at-file-filtration:{os.getenv('ENVIRONMENT', 'latest')}",
+        "env_config_maps": ["dagster-pipeline-env"],
+    }
+)
+def file_filtration_op(context: OpExecutionContext):
+    """File Filtration container operation."""
+    context.log.info("Running File Filtration container")
+
+
+@k8s_job_op(
+    container_config={
+        "image": f"ghcr.io/x81k25/automatic-transmission/at-metadata-collection:{os.getenv('ENVIRONMENT', 'latest')}",
+        "env_config_maps": ["dagster-pipeline-env"],
+    }
+)
+def metadata_collection_op(context: OpExecutionContext):
+    """Metadata Collection container operation."""
+    context.log.info("Running Metadata Collection container")
+
+
+@k8s_job_op(
+    container_config={
+        "image": f"ghcr.io/x81k25/automatic-transmission/at-media-filtration:{os.getenv('ENVIRONMENT', 'latest')}",
+        "env_config_maps": ["dagster-pipeline-env"],
+    }
+)
+def media_filtration_op(context: OpExecutionContext):
+    """Media Filtration container operation."""
+    context.log.info("Running Media Filtration container")
+
+
+@k8s_job_op(
+    container_config={
+        "image": f"ghcr.io/x81k25/automatic-transmission/at-initiation:{os.getenv('ENVIRONMENT', 'latest')}",
+        "env_config_maps": ["dagster-pipeline-env"],
+    }
+)
+def initiation_op(context: OpExecutionContext):
+    """Initiation container operation."""
+    context.log.info("Running Initiation container")
+
+
+@k8s_job_op(
+    container_config={
+        "image": f"ghcr.io/x81k25/automatic-transmission/at-download-check:{os.getenv('ENVIRONMENT', 'latest')}",
+        "env_config_maps": ["dagster-pipeline-env"],
+    }
+)
+def download_check_op(context: OpExecutionContext):
+    """Download Check container operation."""
+    context.log.info("Running Download Check container")
+
+
+@k8s_job_op(
+    container_config={
+        "image": f"ghcr.io/x81k25/automatic-transmission/at-transfer:{os.getenv('ENVIRONMENT', 'latest')}",
+        "env_config_maps": ["dagster-pipeline-env"],
+    }
+)
+def transfer_op(context: OpExecutionContext):
+    """Transfer container operation."""
+    context.log.info("Running Transfer container")
+
+
+@k8s_job_op(
+    container_config={
+        "image": f"ghcr.io/x81k25/automatic-transmission/at-cleanup:{os.getenv('ENVIRONMENT', 'latest')}",
+        "env_config_maps": ["dagster-pipeline-env"],
+    }
+)
+def cleanup_op(context: OpExecutionContext):
+    """Cleanup container operation."""
+    context.log.info("Running Cleanup container")

--- a/dagstributor/automatic_transmission/schedules.py
+++ b/dagstributor/automatic_transmission/schedules.py
@@ -1,0 +1,116 @@
+"""Schedule definitions for automatic transmission pipeline."""
+
+from dagster import schedule
+
+from .jobs import (
+    rss_ingest_job,
+    collect_job,
+    parse_job,
+    file_filtration_job,
+    metadata_collection_job,
+    media_filtration_job,
+    initiation_job,
+    download_check_job,
+    transfer_job,
+    cleanup_job,
+)
+
+
+@schedule(
+    job=rss_ingest_job,
+    cron_schedule="0 * * * *",
+    name="rss_ingest_schedule"
+)
+def rss_ingest_schedule():
+    """RSS Ingest runs at :00 minutes past each hour."""
+    return {}
+
+
+@schedule(
+    job=collect_job,
+    cron_schedule="6 * * * *",
+    name="collect_schedule"
+)
+def collect_schedule():
+    """Collect runs at :06 minutes past each hour."""
+    return {}
+
+
+@schedule(
+    job=parse_job,
+    cron_schedule="12 * * * *",
+    name="parse_schedule"
+)
+def parse_schedule():
+    """Parse runs at :12 minutes past each hour."""
+    return {}
+
+
+@schedule(
+    job=file_filtration_job,
+    cron_schedule="18 * * * *",
+    name="file_filtration_schedule"
+)
+def file_filtration_schedule():
+    """File Filtration runs at :18 minutes past each hour."""
+    return {}
+
+
+@schedule(
+    job=metadata_collection_job,
+    cron_schedule="24 * * * *",
+    name="metadata_collection_schedule"
+)
+def metadata_collection_schedule():
+    """Metadata Collection runs at :24 minutes past each hour."""
+    return {}
+
+
+@schedule(
+    job=media_filtration_job,
+    cron_schedule="30 * * * *",
+    name="media_filtration_schedule"
+)
+def media_filtration_schedule():
+    """Media Filtration runs at :30 minutes past each hour."""
+    return {}
+
+
+@schedule(
+    job=initiation_job,
+    cron_schedule="36 * * * *",
+    name="initiation_schedule"
+)
+def initiation_schedule():
+    """Initiation runs at :36 minutes past each hour."""
+    return {}
+
+
+@schedule(
+    job=download_check_job,
+    cron_schedule="42 * * * *",
+    name="download_check_schedule"
+)
+def download_check_schedule():
+    """Download Check runs at :42 minutes past each hour."""
+    return {}
+
+
+@schedule(
+    job=transfer_job,
+    cron_schedule="48 * * * *",
+    name="transfer_schedule"
+)
+def transfer_schedule():
+    """Transfer runs at :48 minutes past each hour."""
+    return {}
+
+
+@schedule(
+    job=cleanup_job,
+    cron_schedule="54 * * * *",
+    name="cleanup_schedule"
+)
+def cleanup_schedule():
+    """Cleanup runs at :54 minutes past each hour."""
+    return {}

--- a/dagstributor/definitions.py
+++ b/dagstributor/definitions.py
@@ -15,6 +15,30 @@ from .assets import (
     execution_context,
     execution_report,
 )
+from .automatic_transmission.jobs import (
+    rss_ingest_job,
+    collect_job,
+    parse_job,
+    file_filtration_job,
+    metadata_collection_job,
+    media_filtration_job,
+    initiation_job,
+    download_check_job,
+    transfer_job,
+    cleanup_job,
+)
+from .automatic_transmission.schedules import (
+    rss_ingest_schedule,
+    collect_schedule,
+    parse_schedule,
+    file_filtration_schedule,
+    metadata_collection_schedule,
+    media_filtration_schedule,
+    initiation_schedule,
+    download_check_schedule,
+    transfer_schedule,
+    cleanup_schedule,
+)
 
 # Define all assets in the project
 all_assets = [
@@ -35,7 +59,37 @@ all_assets = [
     execution_report,
 ]
 
+# Define all automatic transmission jobs
+at_jobs = [
+    rss_ingest_job,
+    collect_job,
+    parse_job,
+    file_filtration_job,
+    metadata_collection_job,
+    media_filtration_job,
+    initiation_job,
+    download_check_job,
+    transfer_job,
+    cleanup_job,
+]
+
+# Define all automatic transmission schedules
+at_schedules = [
+    rss_ingest_schedule,
+    collect_schedule,
+    parse_schedule,
+    file_filtration_schedule,
+    metadata_collection_schedule,
+    media_filtration_schedule,
+    initiation_schedule,
+    download_check_schedule,
+    transfer_schedule,
+    cleanup_schedule,
+]
+
 # Create the Definitions object
 defs = Definitions(
     assets=all_assets,
+    jobs=at_jobs,
+    schedules=at_schedules,
 )

--- a/repositories/main.py
+++ b/repositories/main.py
@@ -1,0 +1,58 @@
+"""Main repository definition for dagstributor project."""
+
+from dagster import repository
+
+from ..dagstributor.definitions import defs
+from ..dagstributor.automatic_transmission.jobs import (
+    rss_ingest_job,
+    collect_job,
+    parse_job,
+    file_filtration_job,
+    metadata_collection_job,
+    media_filtration_job,
+    initiation_job,
+    download_check_job,
+    transfer_job,
+    cleanup_job,
+)
+from ..dagstributor.automatic_transmission.schedules import (
+    rss_ingest_schedule,
+    collect_schedule,
+    parse_schedule,
+    file_filtration_schedule,
+    metadata_collection_schedule,
+    media_filtration_schedule,
+    initiation_schedule,
+    download_check_schedule,
+    transfer_schedule,
+    cleanup_schedule,
+)
+
+
+@repository
+def dagstributor_repo():
+    """Main repository containing all jobs and schedules."""
+    return [
+        # Automatic transmission jobs
+        rss_ingest_job,
+        collect_job,
+        parse_job,
+        file_filtration_job,
+        metadata_collection_job,
+        media_filtration_job,
+        initiation_job,
+        download_check_job,
+        transfer_job,
+        cleanup_job,
+        # Automatic transmission schedules
+        rss_ingest_schedule,
+        collect_schedule,
+        parse_schedule,
+        file_filtration_schedule,
+        metadata_collection_schedule,
+        media_filtration_schedule,
+        initiation_schedule,
+        download_check_schedule,
+        transfer_schedule,
+        cleanup_schedule,
+    ] + defs.get_all_asset_checks() + defs.get_all_job_definitions() + list(defs.get_all_asset_specs())


### PR DESCRIPTION
- Implement 10 K8s job ops for AT pipeline containers (RSS, collect, parse, filtration, etc.)
- Create hourly schedules with 6-minute staggered intervals (00-54 minutes)
- Configure K8s executor in dagster.yaml for container orchestration
- Pull images from ghcr.io/x81k25/automatic-transmission/ with ENVIRONMENT tag
- Inject environment variables via dagster-pipeline-env ConfigMap

🤖 Generated with [Claude Code](https://claude.ai/code)