### PR TITLE
Change prod environment to use 'main' image tags instead of 'prod'

### DIFF
--- a/dagstributor/automatic_transmission/ops.py
+++ b/dagstributor/automatic_transmission/ops.py
@@ -4,6 +4,11 @@ import os
 from dagster import op, OpExecutionContext
 from dagster_k8s import k8s_job_op
 
+# Image tag logic: prod environment uses 'main' tags, others use environment name
+def get_image_tag():
+    env = os.getenv('ENVIRONMENT', 'dev')
+    return 'main' if env == 'prod' else env
+
 # Global K8s job configuration
 BASE_K8S_CONFIG = {
     "namespace": f"media-{os.getenv('ENVIRONMENT', 'dev')}",
@@ -20,7 +25,7 @@ BASE_K8S_CONFIG = {
 at_01_rss_ingest_op = k8s_job_op.configured(
     {
         **BASE_K8S_CONFIG,
-        "image": f"ghcr.io/x81k25/automatic-transmission/at-01-rss-ingest:{os.getenv('ENVIRONMENT', 'dev')}",
+        "image": f"ghcr.io/x81k25/automatic-transmission/at-01-rss-ingest:{get_image_tag()}",
     },
     name="at_01_rss_ingest_op"
 )
@@ -28,7 +33,7 @@ at_01_rss_ingest_op = k8s_job_op.configured(
 at_02_collect_op = k8s_job_op.configured(
     {
         **BASE_K8S_CONFIG,
-        "image": f"ghcr.io/x81k25/automatic-transmission/at-02-collect:{os.getenv('ENVIRONMENT', 'dev')}",
+        "image": f"ghcr.io/x81k25/automatic-transmission/at-02-collect:{get_image_tag()}",
     },
     name="at_02_collect_op"
 )
@@ -36,7 +41,7 @@ at_02_collect_op = k8s_job_op.configured(
 at_03_parse_op = k8s_job_op.configured(
     {
         **BASE_K8S_CONFIG,
-        "image": f"ghcr.io/x81k25/automatic-transmission/at-03-parse:{os.getenv('ENVIRONMENT', 'dev')}",
+        "image": f"ghcr.io/x81k25/automatic-transmission/at-03-parse:{get_image_tag()}",
     },
     name="at_03_parse_op"
 )
@@ -44,7 +49,7 @@ at_03_parse_op = k8s_job_op.configured(
 at_04_file_filtration_op = k8s_job_op.configured(
     {
         **BASE_K8S_CONFIG,
-        "image": f"ghcr.io/x81k25/automatic-transmission/at-04-file-filtration:{os.getenv('ENVIRONMENT', 'dev')}",
+        "image": f"ghcr.io/x81k25/automatic-transmission/at-04-file-filtration:{get_image_tag()}",
     },
     name="at_04_file_filtration_op"
 )
@@ -52,7 +57,7 @@ at_04_file_filtration_op = k8s_job_op.configured(
 at_05_metadata_collection_op = k8s_job_op.configured(
     {
         **BASE_K8S_CONFIG,
-        "image": f"ghcr.io/x81k25/automatic-transmission/at-05-metadata-collection:{os.getenv('ENVIRONMENT', 'dev')}",
+        "image": f"ghcr.io/x81k25/automatic-transmission/at-05-metadata-collection:{get_image_tag()}",
     },
     name="at_05_metadata_collection_op"
 )
@@ -60,7 +65,7 @@ at_05_metadata_collection_op = k8s_job_op.configured(
 at_06_media_filtration_op = k8s_job_op.configured(
     {
         **BASE_K8S_CONFIG,
-        "image": f"ghcr.io/x81k25/automatic-transmission/at-06-media-filtration:{os.getenv('ENVIRONMENT', 'dev')}",
+        "image": f"ghcr.io/x81k25/automatic-transmission/at-06-media-filtration:{get_image_tag()}",
     },
     name="at_06_media_filtration_op"
 )
@@ -68,7 +73,7 @@ at_06_media_filtration_op = k8s_job_op.configured(
 at_07_initiation_op = k8s_job_op.configured(
     {
         **BASE_K8S_CONFIG,
-        "image": f"ghcr.io/x81k25/automatic-transmission/at-07-initiation:{os.getenv('ENVIRONMENT', 'dev')}",
+        "image": f"ghcr.io/x81k25/automatic-transmission/at-07-initiation:{get_image_tag()}",
     },
     name="at_07_initiation_op"
 )
@@ -76,7 +81,7 @@ at_07_initiation_op = k8s_job_op.configured(
 at_08_download_check_op = k8s_job_op.configured(
     {
         **BASE_K8S_CONFIG,
-        "image": f"ghcr.io/x81k25/automatic-transmission/at-08-download-check:{os.getenv('ENVIRONMENT', 'dev')}",
+        "image": f"ghcr.io/x81k25/automatic-transmission/at-08-download-check:{get_image_tag()}",
     },
     name="at_08_download_check_op"
 )
@@ -84,7 +89,7 @@ at_08_download_check_op = k8s_job_op.configured(
 at_09_transfer_op = k8s_job_op.configured(
     {
         **BASE_K8S_CONFIG,
-        "image": f"ghcr.io/x81k25/automatic-transmission/at-09-transfer:{os.getenv('ENVIRONMENT', 'dev')}",
+        "image": f"ghcr.io/x81k25/automatic-transmission/at-09-transfer:{get_image_tag()}",
     },
     name="at_09_transfer_op"
 )
@@ -92,7 +97,7 @@ at_09_transfer_op = k8s_job_op.configured(
 at_10_cleanup_op = k8s_job_op.configured(
     {
         **BASE_K8S_CONFIG,
-        "image": f"ghcr.io/x81k25/automatic-transmission/at-10-cleanup:{os.getenv('ENVIRONMENT', 'dev')}",
+        "image": f"ghcr.io/x81k25/automatic-transmission/at-10-cleanup:{get_image_tag()}",
     },
     name="at_10_cleanup_op"
 )


### PR DESCRIPTION
- Add get_image_tag() function: prod env → 'main' tags, others → env name
- Update all 10 operations to use get_image_tag() instead of direct env var
- Maintains current behavior for dev/stg, changes prod to pull :main tags
- This should resolve image pull failures in production environment