### PR TITLE
Fix reel-driver feature engineering image name

### DIFF
--- a/dagstributor/reel_driver/ops.py
+++ b/dagstributor/reel_driver/ops.py
@@ -32,7 +32,7 @@ BASE_K8S_CONFIG = {
 reel_driver_training_feature_engineering_op = k8s_job_op.configured(
     {
         **BASE_K8S_CONFIG,
-        "image": f"ghcr.io/x81k25/reel-driver/training-feature-engineering:{get_image_tag()}",
+        "image": f"ghcr.io/x81k25/reel-driver/reel-driver-feature-engineering:{get_image_tag()}",
     },
     name="reel_driver_training_feature_engineering_op"
 )


### PR DESCRIPTION
## Summary
- Fixed incorrect image name for reel-driver feature engineering op
- Changed from `training-feature-engineering` to `reel-driver-feature-engineering`

## Test plan
- [x] Tested successfully in dev environment
- [ ] Deploy to staging and verify

🤖 Generated with [Claude Code](https://claude.ai/code)